### PR TITLE
RFC: FormalAfterReset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
+.bloop
+.metals
 .idea
-**/target
+.jvmops
+target
+project/*
+build/*
+*.v
+*.sv
+*.fir
+*.conf
+*.anno.json
+settings.json

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,10 @@ lazy val commonSettings = Seq(
   libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8",
 )
 
+scalacOptions ++= Seq(
+  "-Xsource:2.11"
+)
+
 lazy val main = (project in file(".")).
   settings(name := "chisel-formal").
   settings(commonSettings: _*)
@@ -32,29 +36,3 @@ val defaultVersions = Map(
   "chisel3" -> "3.4.0-RC1",
   "firrtl" -> "1.4.0-RC1"
 )
-
-//def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
-//  Seq() ++ {
-//    // If we're building with Scala > 2.11, enable the compile option
-//    //  switch to support our anonymous Bundle definitions:
-//    //  https://github.com/scala/bug/issues/10047
-//    CrossVersion.partialVersion(scalaVersion) match {
-//      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
-//      case _ => Seq("-Xsource:2.11")
-//    }
-//  }
-//}
-//
-//def javacOptionsVersion(scalaVersion: String): Seq[String] = {
-//  Seq() ++ {
-//    // Scala 2.12 requires Java 8. We continue to generate
-//    //  Java 7 compatible code for Scala 2.11
-//    //  for compatibility with old clients.
-//    CrossVersion.partialVersion(scalaVersion) match {
-//      case Some((2, scalaMajor: Long)) if scalaMajor < 12 =>
-//        Seq("-source", "1.7", "-target", "1.7")
-//      case _ =>
-//        Seq("-source", "1.8", "-target", "1.8")
-//    }
-//  }
-//}

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq("chisel3","firrtl").map { dep: String =>
     "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
   },
-  libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8",
+  libraryDependencies += "edu.berkeley.cs" %% "chiseltest" % "0.3.0-RC1"
 )
 
 scalacOptions ++= Seq(

--- a/src/main/scala/chisel3/formal/Formal.scala
+++ b/src/main/scala/chisel3/formal/Formal.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.experimental.{verification => v}
 import chisel3.internal.sourceinfo.SourceInfo
 import chisel3.{when => chiselWhen}
+import chisel3.util.experimental.BoringUtils
 
 
 trait Formal {
@@ -14,7 +15,7 @@ trait Formal {
   private val resetCounter = Module(new ResetCounter)
   resetCounter.io.clock := clock
   resetCounter.io.reset := reset
-  val numResets = resetCounter.io.numResets
+  val numResets = WireInit(resetCounter.io.numResets)
   val timeSinceReset = resetCounter.io.timeSinceReset
 
   private val testCase = Module(new TestCase).io.testCase
@@ -94,6 +95,8 @@ trait Formal {
   def afterReset(block: => Any)
                 (implicit sourceInfo: SourceInfo,
                  compileOptions: CompileOptions): Unit = {
+    val numResets = WireInit(0.U(32.W))
+    BoringUtils.bore(this.numResets, Seq(numResets))
     chiselWhen(numResets >= 1.U)(block)
   }
 }

--- a/src/main/scala/chisel3/formal/Formal.scala
+++ b/src/main/scala/chisel3/formal/Formal.scala
@@ -90,4 +90,10 @@ trait Formal {
       block
     }
   }
+
+  def afterReset(block: => Any)
+                (implicit sourceInfo: SourceInfo,
+                 compileOptions: CompileOptions): Unit = {
+    chiselWhen(numResets >= 1.U)(block)
+  }
 }

--- a/src/main/scala/chisel3/formal/FormalAfterReset.scala
+++ b/src/main/scala/chisel3/formal/FormalAfterReset.scala
@@ -1,0 +1,32 @@
+package chisel3.formal
+
+import chisel3._
+import chisel3.internal.sourceinfo.SourceInfo
+
+trait FormalAfterReset extends Formal {
+  this: Module =>
+
+  override def assert(predicate: Bool, message: String = "")
+            (implicit sourceInfo: SourceInfo,
+             compileOptions: CompileOptions): Unit = {
+    afterReset {
+      super.assert(predicate, message)
+    }
+  }
+
+  override def assume(predicate: Bool, message: String = "")
+            (implicit sourceInfo: SourceInfo,
+             compileOptions: CompileOptions): Unit = {
+    afterReset {
+      super.assume(predicate, message)
+    }
+  }
+
+  override def cover(predicate: Bool, message: String = "")
+            (implicit sourceInfo: SourceInfo,
+             compileOptions: CompileOptions): Unit = {
+    afterReset {
+      super.cover(predicate, message)
+    }
+  }
+}

--- a/src/main/scala/chisel3/formal/FormalSpec.scala
+++ b/src/main/scala/chisel3/formal/FormalSpec.scala
@@ -27,58 +27,11 @@ import chisel3.formal.tags.Formal
  * ```
  */
 abstract class FormalSpec extends FlatSpec {
-  val sbyLineNumberPattern = """.*:\s*\d+(?:\.\d+)?-(\d+)(?:\.\d+)?.*""".r
-  val firrtlLineNumberPattern = """.*//\s*@\[(.*)]\s*""".r
   private var counter = 0
   def verify(dutGen: () => RawModule): Unit = {
     it should s"work in instance $counter" taggedAs(Formal) in {
-      val result = Driver(dutGen)
-      val rtlLines = result.rtl.linesIterator.toArray
-      // write out symbiyosys output stream
-      new PrintWriter(s"build/${result.moduleName}_sby_output.log") {
-        write(result.output)
-        close()
-      }
-      // write out symbiyosys error stream
-      new PrintWriter(s"build/${result.moduleName}_sby_error.log") {
-        write(result.error)
-        close()
-      }
-      for (line <- result.output.linesIterator) {
-        checkLine(result, rtlLines, line)
-      }
+      FormalVerify(dutGen)
     }
     counter += 1
-  }
-
-  def checkLine(result: VerificationResult, rtlLines: Array[String],
-                line: String): Unit = {
-    val errorEncountered = line.toLowerCase.contains("error")
-    val assertFailed = line.toLowerCase.contains("assert failed")
-    val coverFailed = line.toLowerCase.contains("unreached cover statement")
-    val message = if (coverFailed) {
-      "Failed to reach cover statement at"
-    } else if (assertFailed) {
-      "Failed to assert condition at"
-    } else {
-      "Error encountered at"
-    }
-    if (assertFailed || coverFailed || errorEncountered) {
-      line match {
-        case sbyLineNumberPattern(rtlLineNumber) => {
-          val rtlLine = rtlLines(rtlLineNumber.toInt-1)
-          rtlLine match {
-            case firrtlLineNumberPattern(scalaLine) => {
-              assert(false, s"$message $scalaLine")
-            }
-            case _ => {
-              assert(false, s"$message ${result.rtlFilename}" +
-                s":$rtlLineNumber (no Scala line ref found): $rtlLine")
-            }
-          }
-        }
-        case _ => assert(false, s"$message $line")
-      }
-    }
   }
 }

--- a/src/main/scala/chisel3/formal/FormalVerify.scala
+++ b/src/main/scala/chisel3/formal/FormalVerify.scala
@@ -1,0 +1,58 @@
+package chisel3.formal
+
+import java.io.PrintWriter
+import chisel3.RawModule
+
+object FormalVerify {
+  def apply(dutGen: () => RawModule): Unit = {
+    val result = Driver(dutGen)
+    val rtlLines = result.rtl.linesIterator.toArray
+    // write out symbiyosys output stream
+    new PrintWriter(s"build/${result.moduleName}_sby_output.log") {
+      write(result.output)
+      close()
+    }
+    // write out symbiyosys error stream
+    new PrintWriter(s"build/${result.moduleName}_sby_error.log") {
+      write(result.error)
+      close()
+    }
+    for (line <- result.output.linesIterator) {
+      checkLine(result, rtlLines, line)
+    }
+  }
+
+  val sbyLineNumberPattern = """.*:\s*\d+(?:\.\d+)?-(\d+)(?:\.\d+)?.*""".r
+  val firrtlLineNumberPattern = """.*//\s*@\[(.*)]\s*""".r
+
+  def checkLine(result: VerificationResult, rtlLines: Array[String],
+                line: String): Unit = {
+    val errorEncountered = line.toLowerCase.contains("error")
+    val assertFailed = line.toLowerCase.contains("assert failed")
+    val coverFailed = line.toLowerCase.contains("unreached cover statement")
+    val message = if (coverFailed) {
+      "Failed to reach cover statement at"
+    } else if (assertFailed) {
+      "Failed to assert condition at"
+    } else {
+      "Error encountered at"
+    }
+    if (assertFailed || coverFailed || errorEncountered) {
+      line match {
+        case sbyLineNumberPattern(rtlLineNumber) => {
+          val rtlLine = rtlLines(rtlLineNumber.toInt-1)
+          rtlLine match {
+            case firrtlLineNumberPattern(scalaLine) => {
+              assert(false, s"$message $scalaLine")
+            }
+            case _ => {
+              assert(false, s"$message ${result.rtlFilename}" +
+                s":$rtlLineNumber (no Scala line ref found): $rtlLine")
+            }
+          }
+        }
+        case _ => assert(false, s"$message $line")
+      }
+    }
+  }
+}

--- a/src/test/scala/FormalAfterResetTest.scala
+++ b/src/test/scala/FormalAfterResetTest.scala
@@ -1,0 +1,47 @@
+package test
+
+import chisel3._
+import chisel3.formal._
+
+class TestModule extends Module {
+    val io = IO(new Bundle {
+        val in = Input(Bool())
+        val a = Output(Bool())
+        val b = Output(Bool())
+    })
+
+    val aReg = RegInit(true.B)
+    val bReg = RegInit(false.B)
+    io.a := aReg
+    io.b := bReg
+
+    aReg :=  io.in
+    bReg := !io.in
+}
+
+// This should fail.
+class TestModuleFormal extends TestModule with Formal {
+    assert(aReg === !bReg)
+}
+// This should not.
+class TestModuleFormalAfterReset extends TestModule with FormalAfterReset {
+    assert(aReg === !bReg)
+}
+
+
+class TestFormalSpec extends FormalSpec {
+    behavior of "FormalAfterReset"
+    it should "only enforce assertions after reset" in {
+        FormalVerify(() => new TestModuleFormalAfterReset)
+    }
+
+    behavior of "Formal"
+    it should "enforce assertions before reset" in {
+        try {
+            FormalVerify(() => new TestModuleFormal)
+            assert(false)
+        } catch {
+            case e: java.lang.AssertionError => {}
+        }
+    }
+}

--- a/src/test/scala/PublicMethodWithWhen.scala
+++ b/src/test/scala/PublicMethodWithWhen.scala
@@ -1,0 +1,43 @@
+package test
+
+import chisel3._
+import chisel3.formal._
+import chiseltest._
+import org.scalatest._
+
+/* This is a test case for a Module that uses FormalAfterReset and exposes public methods that use "when". */
+
+class PublicMethodWithWhen extends FlatSpec with ChiselScalatestTester with Matchers {
+    class ModuleWithMethod extends Module with FormalAfterReset {
+        val io = IO(new Bundle {
+            val in = Input(Bool())
+        })
+    
+        def onTrue(block: => Any) = when(io.in)(block)
+    }
+
+    class ModuleThatUsesMethod extends Module {
+        val io = IO(new Bundle {
+            val in = Input(Bool())
+            val out = Output(Bool())
+        })
+
+        val m = Module(new ModuleWithMethod())
+        m.io.in := io.in
+
+        io.out := false.B
+        m.onTrue {
+            io.out := true.B
+        }
+    }
+
+    it should "not throw an exception" in {
+        test(new ModuleThatUsesMethod()) { c=>
+            c.io.in.poke(false.B)
+            c.io.out.expect(false.B)
+
+            c.io.in.poke(true.B)
+            c.io.out.expect(true.B)
+        }
+    }
+}


### PR DESCRIPTION
This is related to #4.

These changes add a new `FormalAfterReset` trait for modules where the assertions should only apply after a reset.
This is just a prototype to start the discussion. I will to redo the whole thing if I have to.