### PR TITLE
Update Chisel, cleanup build.sbt, and add test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,60 +1,22 @@
 lazy val commonSettings = Seq(
   organization := "edu.berkeley.cs",
   version := "0.1-SNAPSHOT",
-  //scalaVersion := "2.13.3",
-  scalaVersion := "2.12.10",
-//  crossScalaVersions := Seq("2.12.10", "2.11.12"),
+  scalaVersion := "2.12.12",
   resolvers ++= Seq(
     Resolver.sonatypeRepo("snapshots"),
     Resolver.sonatypeRepo("releases")
   ),
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
-  libraryDependencies ++= Seq("chisel3","firrtl").map { dep: String =>
-    "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
-  },
+  libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.4.0",
   libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8",
 )
 
 lazy val main = (project in file(".")).
   settings(name := "chisel-formal").
-  settings(commonSettings: _*)
-//  dependsOn(macros)
+  settings(commonSettings: _*).
+  settings(
+    Test / scalacOptions += "-Xsource:2.11"
+  )
 
-lazy val macros = (project in file("macros")).
-  settings(name := "chisel3-formal-macros").
-  settings(commonSettings: _*)
-//  settings(publishSettings: _*)
 
-// Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
-// The following are the default development versions, not the "release" versions.
-val defaultVersions = Map(
-  "chisel3" -> "3.4.0-RC1",
-  "firrtl" -> "1.4.0-RC1"
-)
-
-//def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
-//  Seq() ++ {
-//    // If we're building with Scala > 2.11, enable the compile option
-//    //  switch to support our anonymous Bundle definitions:
-//    //  https://github.com/scala/bug/issues/10047
-//    CrossVersion.partialVersion(scalaVersion) match {
-//      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
-//      case _ => Seq("-Xsource:2.11")
-//    }
-//  }
-//}
-//
-//def javacOptionsVersion(scalaVersion: String): Seq[String] = {
-//  Seq() ++ {
-//    // Scala 2.12 requires Java 8. We continue to generate
-//    //  Java 7 compatible code for Scala 2.11
-//    //  for compatibility with old clients.
-//    CrossVersion.partialVersion(scalaVersion) match {
-//      case Some((2, scalaMajor: Long)) if scalaMajor < 12 =>
-//        Seq("-source", "1.7", "-target", "1.7")
-//      case _ =>
-//        Seq("-source", "1.8", "-target", "1.8")
-//    }
-//  }
-//}

--- a/src/test/scala/chisel3/formal/SanitySpec.scala
+++ b/src/test/scala/chisel3/formal/SanitySpec.scala
@@ -1,0 +1,31 @@
+
+// Intentionally different package to test public API
+package chiselFormalTests
+
+import chisel3._
+import chisel3.formal.{Formal, FormalSpec}
+
+class KeepMax(width: Int) extends Module with Formal {
+  val io = IO(new Bundle {
+    val in = Input(UInt(width.W))
+    val out = Output(UInt(width.W))
+  })
+
+  val max = RegInit(0.U(width.W))
+  when (io.in > max) {
+    max := io.in
+  }
+  io.out := max
+
+  // get the value of io.out from 1 cycle in the past
+  past(io.out, 1) (pastIoOut => {
+    assert(io.out >= pastIoOut)
+  })
+}
+
+class SanitySpec extends FormalSpec {
+  Seq(
+    () => new KeepMax(1),
+    () => new KeepMax(8),
+  ).map(verify(_))
+}


### PR DESCRIPTION
* Update Chisel to 3.4.0
* Remove comments and unnecessary complexity in build.sbt
* Add a sanity test

My main goal was to bump Chisel in light of https://github.com/tdb-alcorn/chisel-formal/issues/9.

I tried to make the build.sbt simpler, sorry if I'm stepping on any toes here. Let me know and I can undo whatever.

In bumping I realized I didn't know how to test this repo other than running compile so I added a sanity test.
I copy-pasted the test from the README.

**WARNING**: I am on a shared machine and had issues getting SymbiYosys working so I cannot verify that the test actually works. It at least runs the Chisel pieces.